### PR TITLE
missing declare 'var'

### DIFF
--- a/src/grid/table.js
+++ b/src/grid/table.js
@@ -30,7 +30,7 @@ export default {
                 var row = this.grid.rows;
                 var column = this.grid.columns;
 
-                padding = this.grid.padding;
+                var padding = this.grid.padding;
 
                 var columnUnit = (this.axis.area('width') -  (column - 1) * padding) / column;
                 var rowUnit = (this.axis.area('height') - (row - 1) * padding ) / row;


### PR DESCRIPTION
grid.table 사용 시 padding 변수에서 오류가 발생합니다.
'var' 변수 선언이 누락되었습니다.